### PR TITLE
Fix wait_finished loop and example amplitude call

### DIFF
--- a/drivers/base_instruments.py
+++ b/drivers/base_instruments.py
@@ -29,7 +29,7 @@ class base_visa_instrument:
 
     def wait_finished(self):
 
-        while not self.query('*OPC?') == '1':
+        while self.query('*OPC?').strip() != '1':
             pass
 
         return

--- a/drivers/rigol.py
+++ b/drivers/rigol.py
@@ -59,7 +59,7 @@ if __name__ == "__main__":
     fg.id()
 
     fg.set_freq(8.0)
-    fg.set_level(0.0)
+    fg.set_ampl(0.0)
 
     fg.close()
 


### PR DESCRIPTION
## Summary
- Prevent infinite loop in `base_instruments.wait_finished` by normalizing instrument responses.
- Correct Rigol example to call existing `set_ampl` method instead of missing `set_level`.

## Testing
- `python -m py_compile drivers/base_instruments.py drivers/rigol.py`


------
https://chatgpt.com/codex/tasks/task_e_68c092fd963083229ee269d4049f010b